### PR TITLE
add 'osx' to os_patterns

### DIFF
--- a/get_os_name.lua
+++ b/get_os_name.lua
@@ -50,6 +50,7 @@ function M.get_os_name()
     local os_patterns = {
         ['windows']     = 'Windows',
         ['linux']       = 'Linux',
+        ['osx']         = 'Mac',
         ['mac']         = 'Mac',
         ['darwin']      = 'Mac',
         ['^mingw']      = 'Windows',


### PR DESCRIPTION
I was having trouble identifying my Mac with your script and realized that the output of `jit.os` was `OSX`, which was missing from the list of os_patterns